### PR TITLE
docs: fix a spelling error at the links in en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ ok  	github.com/cloudwego/shmipc	42.138s
 
 #### HelloWorld
 
-- [HelloWorldClient](https://github.com/cloudwego/shmipc-go/blob/main/example/helloword/greeter_client/main.go)
-- [HelloWorldServer](https://github.com/cloudwego/shmipc-go/blob/main/example/helloword/greeter_server/main.go)
+- [HelloWorldClient](https://github.com/cloudwego/shmipc-go/blob/main/example/helloworld/greeter_client/main.go)
+- [HelloWorldServer](https://github.com/cloudwego/shmipc-go/blob/main/example/helloworld/greeter_server/main.go)
 
 #### Integrate with application
 


### PR DESCRIPTION
#### What type of PR is this?

docs

#### What this PR does / why we need it (en: English/zh: Chinese):

en: fix a spelling error at the links in en README
zh: 修复了英文 README 中一个由单词拼写导致的示例代码链接错误

#### Which issue(s) this PR fixes:
