### PR TITLE
perf: uses RWMutex

### DIFF
--- a/protocol_manager.go
+++ b/protocol_manager.go
@@ -327,10 +327,7 @@ func handleStreamClose(s *Session, hdr header, buf []byte) (int, bool, error) {
 	id := binary.BigEndian.Uint32(buf[:4])
 	s.logger.debugf("receive peer stream[%d] goaway.", id)
 
-	s.streamLock.Lock()
-	stream := s.streams[id]
-	s.streamLock.Unlock()
-
+	stream := s.getStreamById(id)
 	if stream == nil {
 		s.logger.warnf("missing stream: %d", id)
 		return headerSize + idLen, false, nil

--- a/session_test.go
+++ b/session_test.go
@@ -237,8 +237,8 @@ func TestSendData_Small(t *testing.T) {
 			t.Logf("err: %v", err)
 		}
 
-		if server.ActiveStreams() != 1 {
-			t.Fatal("num of streams is ", server.ActiveStreams())
+		if server.GetActiveStreamCount() != 1 {
+			t.Fatal("num of streams is ", server.GetActiveStreamCount())
 		}
 
 		size := 0
@@ -265,7 +265,7 @@ func TestSendData_Small(t *testing.T) {
 			t.Logf("err: %v", err)
 		}
 
-		if client.ActiveStreams() != 1 {
+		if client.GetActiveStreamCount() != 1 {
 			t.Logf("bad")
 		}
 
@@ -296,10 +296,10 @@ func TestSendData_Small(t *testing.T) {
 		panic("timeout")
 	}
 
-	if client.ActiveStreams() != 0 {
-		t.Fatalf("bad, streams:%d", client.ActiveStreams())
+	if client.GetActiveStreamCount() != 0 {
+		t.Fatalf("bad, streams:%d", client.GetActiveStreamCount())
 	}
-	if server.ActiveStreams() != 0 {
+	if server.GetActiveStreamCount() != 0 {
 		t.Fatalf("bad")
 	}
 }
@@ -449,8 +449,8 @@ func TestSendData_Small_Memfd(t *testing.T) {
 			t.Logf("err: %v", err)
 		}
 
-		if server.ActiveStreams() != 1 {
-			t.Fatal("num of streams is ", server.ActiveStreams())
+		if server.GetActiveStreamCount() != 1 {
+			t.Fatal("num of streams is ", server.GetActiveStreamCount())
 		}
 
 		size := 0
@@ -477,7 +477,7 @@ func TestSendData_Small_Memfd(t *testing.T) {
 			t.Logf("err: %v", err)
 		}
 
-		if client.ActiveStreams() != 1 {
+		if client.GetActiveStreamCount() != 1 {
 			t.Logf("bad")
 		}
 
@@ -508,10 +508,10 @@ func TestSendData_Small_Memfd(t *testing.T) {
 		panic("timeout")
 	}
 
-	if client.ActiveStreams() != 0 {
-		t.Fatalf("bad, streams:%d", client.ActiveStreams())
+	if client.GetActiveStreamCount() != 0 {
+		t.Fatalf("bad, streams:%d", client.GetActiveStreamCount())
 	}
-	if server.ActiveStreams() != 0 {
+	if server.GetActiveStreamCount() != 0 {
 		t.Fatalf("bad")
 	}
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -51,7 +51,7 @@ func newClientServerWithNoCheck(conf *Config) (client *Session, server *Session)
 	return client, server
 }
 
-//Close                           94.4%
+// Close                           94.4%
 func TestStream_Close(t *testing.T) {
 	c := testConf()
 	c.QueueCap = 1
@@ -72,10 +72,10 @@ func TestStream_Close(t *testing.T) {
 		<-hadForceCloseNotifyCh
 		_, err = s.BufferReader().ReadByte()
 		assert.Equal(t, ErrEndOfStream, err)
-		assert.Equal(t, 1, server.ActiveStreams())
+		assert.Equal(t, 1, server.GetActiveStreamCount())
 		assert.Equal(t, uint32(streamHalfClosed), s.state)
 		s.Close()
-		assert.Equal(t, 0, server.ActiveStreams())
+		assert.Equal(t, 0, server.GetActiveStreamCount())
 		assert.Equal(t, uint32(streamClosed), s.state)
 		close(doneCh)
 	}()
@@ -226,7 +226,7 @@ func TestStream_RandomPackageSize(t *testing.T) {
 
 }
 
-//TODO:halfClose                       75.0%
+// TODO:halfClose                       75.0%
 func TestStream_HalfClose(t *testing.T) {
 	conf := testConf()
 	conf.ShareMemoryBufferCap = 1 << 20
@@ -404,7 +404,7 @@ func TestStream_SendQueueFullTimeout(t *testing.T) {
 	}
 }
 
-//reset                           92.9%
+// reset                           92.9%
 func TestStream_Reset(t *testing.T) {
 	conf := testConf()
 	client, server := testClientServerConfig(conf)
@@ -509,7 +509,7 @@ func TestStream_fillDataToReadBuffer(t *testing.T) {
 
 }
 
-//TODO: SwapBufferForReuse              66.7%
+// TODO: SwapBufferForReuse              66.7%
 func TestStream_SwapBufferForReuse(t *testing.T) {
 
 }


### PR DESCRIPTION
#### What type of PR is this?
perf
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: session streamLock, sessoin_manager SessionManager uses RWMutex,
zh(optional): session中的streamlock, session_manager中的SessionManager 使用读写锁
